### PR TITLE
Tag calico/go-build with compiler versions

### DIFF
--- a/.github/workflows/create-branch-on-merge.yaml
+++ b/.github/workflows/create-branch-on-merge.yaml
@@ -1,0 +1,34 @@
+name: Create new branch on pull request merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  create-branch:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate branch name
+        id: generate-branch-name
+        run: |
+          BRANCH_NAME=$(./generate-version-tag.sh)
+          echo "Branch name: $BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create and push new branch (if not exists)
+        run: |
+          BRANCH_NAME=${{ steps.generate-branch-name.outputs.branch_name }}
+          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+            echo "Branch $BRANCH_NAME already exists"
+          else
+            echo "Create branch $BRANCH_NAME"
+            git config user.name marvin-tigera
+            git config.user.email marvin@projectcalico.io
+            git checkout -b "$BRANCH_NAME"
+            git push origin "$BRANCH_NAME"

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,8 @@ else ifeq ($(ARCH),s390)
 	override LDSONAME=ld64.so.1
 endif
 
-
-VERSION ?= latest
-
 GOBUILD ?= calico/go-build
-GOBUILD_IMAGE ?= $(GOBUILD):$(VERSION)
+GOBUILD_IMAGE ?= $(GOBUILD):$(shell ./generate-version-tag.sh)
 GOBUILD_ARCH_IMAGE ?= $(GOBUILD_IMAGE)-$(ARCH)
 
 BASE ?= calico/base
@@ -166,8 +163,5 @@ cd:
 ifndef CONFIRM
 	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
 endif
-ifndef BRANCH_NAME
-	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
-endif
-	$(MAKE) push-all VERSION=${BRANCH_NAME}
-	$(MAKE) push-manifest VERSION=${BRANCH_NAME}
+	$(MAKE) push-all
+	$(MAKE) push-manifest

--- a/generate-version-tag.sh
+++ b/generate-version-tag.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+ver_file="$1"
+if [[ -z $ver_file ]]; then
+    ver_file=versions.yaml
+fi
+
+golang_ver=$(yq -r .golang.version "$ver_file")
+k8s_ver=$(yq -r .kubernetes.version "$ver_file")
+llvm_ver=$(yq -r .llvm.version "$ver_file")
+
+if [[ -z $golang_ver ]] || [[ -z $k8s_ver ]] || [[ -z $llvm_ver ]]; then
+    exit 1
+fi
+
+echo "${golang_ver}-llvm${llvm_ver}-k8s${k8s_ver}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,0 +1,12 @@
+golang:
+  version: 1.23.3
+  checksum:
+    sha256:
+      amd64: a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
+      arm64: 1f7cbd7f668ea32a107ecd41b6488aaee1f5d77a66efd885b175494439d4e1ce
+      ppc64le: e3b926c81e8099d3cee6e6e270b85b39c3bd44263f8d3df29aacb4d7e00507c8
+      s390x: 6bd72fcef72b046b6282c2d1f2c38f31600e4fe9361fcd8341500c754fb09c38
+kubernetes:
+  version: 1.30.5
+llvm:
+  version: 18.1.8


### PR DESCRIPTION
This change tags calico/go-build container image with more meaningful compiler versions. The new tag includes golang, clang, and kubernetes versions. If any of the three versions are updated, the new github action will create a branch with the same tag name. The new branch will then trigger semaphore builds and push images to dockerhub.