### PR TITLE
Fix git tag creation and calico/go-build image tag

### DIFF
--- a/.github/workflows/create-branch-on-go-version-change.yml
+++ b/.github/workflows/create-branch-on-go-version-change.yml
@@ -1,12 +1,11 @@
 name: Create new Git branch on Go compiler version change
 
 on:
+  # create a new go1.x branch and a release tag when changes are merged to the master branch
   pull_request:
     types:
       - closed
     branches:
-      # create a new go1.x branch when changes to golang version are merged
-      # to the master branch
       - master
 
 jobs:
@@ -27,6 +26,13 @@ jobs:
           echo "Git branch name: $branch_name"
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
+      - name: Generate tag name
+        id: generate-tag-name
+        run: |
+          tag_name=$(hack/generate-version-tag-name.sh -f images/calico-go-build/versions.yaml)
+          echo "Git tag name: $tag_name"
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+
       - name: Create and push new branch (if not exists)
         run: |
           branch_name=${{ steps.generate-go-branch-name.outputs.branch_name }}
@@ -36,7 +42,13 @@ jobs:
             git config user.name "${{ github.actor }}"
             git config user.email "${{ github.actor }}@users.noreply.github.com"
             git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+
             git checkout -b "$branch_name"
             git push origin "$branch_name"
             echo "Created Git branch $branch_name"
+
+            tag_name=${{ steps.generate-tag-name.outputs.tag_name }}
+            git tag -a "$tag_name" -m "Release $tag_name"
+            git push origin "$tag_name"
+            echo "Created Git tag $tag_name"
           fi

--- a/.github/workflows/create-tag-on-version-change.yml
+++ b/.github/workflows/create-tag-on-version-change.yml
@@ -1,13 +1,11 @@
 name: Create new Git tag on compiler version change
 
 on:
+  # create a new release tag when changes are merged to the go1.x release branches
   pull_request:
     types:
       - closed
     branches:
-      # create a release tag when changes to compiler versions are merged
-      # to the master branch or go1.x release branches.
-      - master
       - go1.*
 
 jobs:
@@ -39,6 +37,7 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+
           git tag -a "$tag_name" -m "Release $tag_name"
           git push origin "$tag_name"
           echo "Created Git tag $tag_name"

--- a/.semaphore/promotions/calico-base.yml
+++ b/.semaphore/promotions/calico-base.yml
@@ -22,8 +22,8 @@ global_job_config:
 blocks:
   - name: Publish calico/base multi-arch images
     dependencies: []
-    skip:
-      when: "branch !~ '.+'"
+    run:
+      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
     task:
       env_vars:
         - name: BRANCH_NAME

--- a/.semaphore/promotions/calico-go-build.yml
+++ b/.semaphore/promotions/calico-go-build.yml
@@ -23,22 +23,17 @@ global_job_config:
       # number in the tag. This is handled in create-tag-on-version-change github workflow.
       - |
         if [ "${SEMAPHORE_GIT_REF_TYPE}" = "tag" ]; then
-          export VERSION_TAG=${SEMAPHORE_GIT_TAG_NAME};
+          export BRANCH_NAME=${SEMAPHORE_GIT_TAG_NAME}
         else
-          export VERSION_TAG=$(hack/generate-version-tag-name.sh -f images/calico-go-build/versions.yaml)
+          export BRANCH_NAME=${SEMAPHORE_GIT_WORKING_BRANCH}
         fi
 
 blocks:
   - name: Publish calico/go-build images
     dependencies: []
-    skip:
-      when: "branch !~ '.+'"
+    run:
+      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
     task:
-      env_vars:
-        - name: BRANCH_NAME
-          value: ${VERSION_TAG}
-        - name: LATEST_IMAGE_TAG
-          value: ${VERSION_TAG}
       jobs:
         - name: Linux multi-arch
           commands:
@@ -46,8 +41,8 @@ blocks:
   - name: Trigger calico/go-build pin updates
     dependencies:
       - Publish calico/go-build images
-    skip:
-      when: "branch !~ '.+'"
+    run:
+      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
     task:
       secrets:
         - name: semaphore-api

--- a/.semaphore/promotions/qemu-user-static.yml
+++ b/.semaphore/promotions/qemu-user-static.yml
@@ -22,8 +22,8 @@ global_job_config:
 blocks:
   - name: Publish calico/qemu-user-static amd64 image
     dependencies: []
-    skip:
-      when: "branch !~ '.+'"
+    run:
+      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
     task:
       env_vars:
         - name: BRANCH_NAME

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,24 +23,22 @@ global_job_config:
       # Semaphore is doing shallow clone on a commit without tags.
       # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
       - git fetch --unshallow
-      - export VERSION_TAG=$(hack/generate-version-tag-name.sh -f images/calico-go-build/versions.yaml)
+      - export VERSION_TAG=${SEMAPHORE_GIT_WORKING_BRANCH}
 
 promotions:
-  # Publish calico/base and calico/qemu-user-static images for master or go1.x branch changes.
-  # Publish calico/go-build images for both master and release tags.
+  # Publish images for master or release tags (example: 1.23.3-llvm18.1.8-k8s1.30.5).
   - name: Publish calico/base images
     pipeline_file: promotions/calico-base.yml
     auto_promote:
-      when: "branch =~ 'master|go1\\.\\d+'"
+      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
   - name: Publish calico/go-build images
     pipeline_file: promotions/calico-go-build.yml
     auto_promote:
-      # release tag name example: 1.23.3-llvm18.1.8-k8s1.30.5
       when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
   - name: Publish calico/qemu-user-static image
     pipeline_file: promotions/qemu-user-static.yml
     auto_promote:
-      when: "branch =~ 'master|go1\\.\\d+'"
+      when: "branch = 'master' OR tag =~ '^1\\.\\d+\\.\\d-llvm\\d+\\.\\d\\.\\d-k8s1\\.\\d+\\.\\d'"
 
 blocks:
   - name: calico/go-build image

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,19 +1,13 @@
 include ../lib.Makefile
 include ../Makefile.common
 
+VERSION_TAG ?= latest
+
 CALICO_BASE ?= base
-CALICO_BASE_IMAGE ?= $(CALICO_BASE):latest
-CALICO_BASE_ARCH_IMAGE ?= $(CALICO_BASE_IMAGE)-$(ARCH)
+CALICO_GO_BUILD ?= go-build
 
 QEMU_USER_STATIC ?= $(DEV_REGISTRIES)/qemu-user-static
-QEMU_USER_STATIC_IMAGE ?= $(QEMU_USER_STATIC):latest
 QEMU_USER_STATIC_IMAGE_CREATED = .qemu-user-static.created
-
-VERSION_TAG ?= $(shell ../hack/generate-version-tag-name.sh -f calico-go-build/versions.yaml)
-
-CALICO_GO_BUILD ?= go-build
-CALICO_GO_BUILD_IMAGE ?= $(CALICO_GO_BUILD):$(VERSION_TAG)
-CALICO_GO_BUILD_ARCH_IMAGE ?= $(CALICO_GO_BUILD_IMAGE)-$(ARCH)
 
 .PHONY: image
 image: qemu-user-static-image calico-base-image calico-go-build-image
@@ -27,13 +21,13 @@ image-all: qemu-user-static-image calico-base-image-all calico-go-build-image-al
 qemu-user-static-image: $(QEMU_USER_STATIC_IMAGE_CREATED)
 $(QEMU_USER_STATIC_IMAGE_CREATED):
 	docker buildx build $(DOCKER_PROGRESS) --load --platform=linux/amd64 --pull \
-		-t $(QEMU_USER_STATIC_IMAGE) \
+		-t $(QEMU_USER_STATIC):latest \
 		-f qemu-user-static/Dockerfile qemu-user-static/
 	touch $@
 
 .PHONY: qemu-user-static-cd
 qemu-user-static-cd: qemu-user-static-image
-	docker push $(QEMU_USER_STATIC_IMAGE)
+	docker push $(QEMU_USER_STATIC):latest
 
 # Base image for all calico components.
 
@@ -51,7 +45,7 @@ endif
 
 .PHONY: calico-base-image
 calico-base-image: register qemu-user-static-image
-	$(DOCKER_BUILD) --build-arg LDSONAME=$(LDSONAME) -t $(CALICO_BASE_ARCH_IMAGE) -f calico-base/Dockerfile calico-base/
+	$(DOCKER_BUILD) --build-arg LDSONAME=$(LDSONAME) -t $(CALICO_BASE):latest-$(ARCH) -f calico-base/Dockerfile calico-base/
 	$(MAKE) BUILD_IMAGES=$(CALICO_BASE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 
 .PHONY: calico-base-image-all
@@ -72,8 +66,8 @@ build:
 
 .PHONY: calico-go-build-image
 calico-go-build-image: register qemu-user-static-image build
-	$(DOCKER_BUILD) -t $(CALICO_GO_BUILD_ARCH_IMAGE) -f calico-go-build/Dockerfile calico-go-build/
-	$(MAKE) BUILD_IMAGES=$(CALICO_GO_BUILD) retag-build-images-with-registries VALIDARCHES=$(ARCH) LATEST_IMAGE_TAG=$(VERSION_TAG) IMAGETAG=$(VERSION_TAG)
+	$(DOCKER_BUILD) -t $(CALICO_GO_BUILD):latest-$(ARCH) -f calico-go-build/Dockerfile calico-go-build/
+	$(MAKE) BUILD_IMAGES=$(CALICO_GO_BUILD) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=$(VERSION_TAG)
 
 .PHONY: calico-go-build-image-all
 calico-go-build-image-all: $(addprefix sub-calico-go-build-image-,$(VALIDARCHES))


### PR DESCRIPTION
This change creates a release tag after a new go1.x branch is created. It also fixes calico/go-build image tag for local and branch builds.