### PR TITLE
[go1.23] Fake bump go to v1.23.5

### DIFF
--- a/images/calico-go-build/versions.yaml
+++ b/images/calico-go-build/versions.yaml
@@ -1,5 +1,5 @@
 golang:
-  version: 1.23.4
+  version: 1.23.5
   checksum:
     sha256:
       amd64: 6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971


### PR DESCRIPTION
Pick https://github.com/hjiawei/go-build/pull/15 into go1.23 release branch.